### PR TITLE
#9 Replace sed with grep for cross-platform compat

### DIFF
--- a/commands/host/1x-token-setup
+++ b/commands/host/1x-token-setup
@@ -72,7 +72,7 @@ fi
 # Setup token for NPM
 # Remove old token if exists to replace with new one, or just append
 # A simple append might create duplicates, so let's try to be a bit smarter or just append as requested
-sed -i '/\/\/git.1xinternet.de\/api\/v4\/packages\/npm\/:_authToken=/d' ~/.ddev/homeadditions/.npmrc
+grep -v '//git.1xinternet.de/api/v4/packages/npm/:_authToken=' ~/.ddev/homeadditions/.npmrc > /tmp/.npmrc_tmp && mv /tmp/.npmrc_tmp ~/.ddev/homeadditions/.npmrc || true
 echo "//git.1xinternet.de/api/v4/packages/npm/:_authToken=${PERSONAL_ACCESS_TOKEN}" >> ~/.ddev/homeadditions/.npmrc
 
 # Configure NPM in homeadditions so the container picks it up.


### PR DESCRIPTION
The safest cross-platform fix is to use `grep -v` with a temp file instead of `sed`                                                                                               