### PR TITLE
#25 Update sed command to remove old auth token pattern

### DIFF
--- a/commands/host/1x-token-setup
+++ b/commands/host/1x-token-setup
@@ -77,10 +77,10 @@ fi
 # Make this work on MacOS and Linux >.<
 if [[ $OSTYPE == darwin* ]]; then
     # "in-place editing only works for regular files" thus change directly ~/.npmrc
-    sed -i '' '/\/\/git.1xinternet.de\/api\/v4\/packages\/npm\/:_authToken=/d' ~/.npmrc
+    sed -i '' '/\/\/git.1xinternet.de\/:_authToken=/d' ~/.npmrc
 else
     # "In-place editing" works also for symlinks on Linux, but for consistency's sake.
-    sed -i '/\/\/git.1xinternet.de\/api\/v4\/packages\/npm\/:_authToken=/d' ~/.npmrc
+    sed -i '/\/\/git.1xinternet.de\/:_authToken=/d' ~/.npmrc
 fi
 echo "//git.1xinternet.de/:_authToken=${PERSONAL_ACCESS_TOKEN}" >> ~/.ddev/homeadditions/.npmrc
 


### PR DESCRIPTION
This should match `echo "//git.1xinternet.de/:_authToken=${PERSONAL_ACCESS_TOKEN}" >> ~/.ddev/homeadditions/.npmrc`